### PR TITLE
Shuffle the json parsing around

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -20,7 +20,7 @@ class WebhookJob < ApplicationJob
       end
     end
 
-    handler = GitHub::EventMessages.handler_for(event_type, body)
+    handler = GitHub::EventMessages.handler_for(event_type, JSON.load(body))
     if handler && handler.response
       response = handler.response
       response[:channel] = org.default_room_for(handler.repo_name)

--- a/app/models/git_hub/event_messages/delete.rb
+++ b/app/models/git_hub/event_messages/delete.rb
@@ -3,7 +3,7 @@ module GitHub::EventMessages
   class Delete
     attr_accessor :body
     def initialize(body)
-      @body = JSON.parse(body)
+      @body = body
     end
 
     def repo_name

--- a/app/models/git_hub/event_messages/deployment_status.rb
+++ b/app/models/git_hub/event_messages/deployment_status.rb
@@ -3,7 +3,7 @@ module GitHub::EventMessages
   class DeploymentStatus
     attr_accessor :body
     def initialize(body)
-      @body = JSON.parse(body)
+      @body = body
     end
 
     def repo_name

--- a/app/models/git_hub/event_messages/ping.rb
+++ b/app/models/git_hub/event_messages/ping.rb
@@ -3,7 +3,7 @@ module GitHub::EventMessages
   class Ping
     attr_accessor :body
     def initialize(body)
-      @body = JSON.parse(body)
+      @body = body
     end
 
     def repo_name

--- a/app/models/git_hub/event_messages/pull_request.rb
+++ b/app/models/git_hub/event_messages/pull_request.rb
@@ -3,7 +3,7 @@ module GitHub::EventMessages
   class PullRequest
     attr_accessor :body
     def initialize(body)
-      @body = JSON.parse(body)
+      @body = body
     end
 
     def repo_name

--- a/app/models/git_hub/event_messages/push.rb
+++ b/app/models/git_hub/event_messages/push.rb
@@ -3,7 +3,7 @@ module GitHub::EventMessages
   class Push
     attr_accessor :body
     def initialize(body)
-      @body = JSON.parse(body)
+      @body = body
     end
 
     def repo_name

--- a/app/models/git_hub/event_messages/status.rb
+++ b/app/models/git_hub/event_messages/status.rb
@@ -3,7 +3,7 @@ module GitHub::EventMessages
   class Status
     attr_accessor :body
     def initialize(body)
-      @body = JSON.parse(body)
+      @body = body
     end
 
     def repo_name
@@ -60,6 +60,8 @@ module GitHub::EventMessages
 
     def actor
       commit["committer"]["login"]
+    rescue StandardError
+      "Unknown"
     end
 
     def commit

--- a/app/models/git_hub/event_messages/unknown.rb
+++ b/app/models/git_hub/event_messages/unknown.rb
@@ -3,7 +3,7 @@ module GitHub::EventMessages
   class Unknown
     attr_accessor :body, :event_type
     def initialize(body, event_type)
-      @body       = JSON.parse(body)
+      @body       = body
       @event_type = event_type
     end
 

--- a/spec/models/git_hub/event_messages/delete_spec.rb
+++ b/spec/models/git_hub/event_messages/delete_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 # rubocop:disable Metrics/LineLength
 RSpec.describe GitHub::EventMessages::Delete, type: :model do
   it "creates a push Slack Message" do
-    data = fixture_data("webhooks/delete")
+    data = decoded_fixture_data("webhooks/delete")
 
     handler = GitHub::EventMessages::Delete.new(data)
 

--- a/spec/models/git_hub/event_messages/deployment_status_spec.rb
+++ b/spec/models/git_hub/event_messages/deployment_status_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 # rubocop:disable Metrics/LineLength
 RSpec.describe GitHub::EventMessages::DeploymentStatus, type: :model do
   it "returns a started message the state is pending" do
-    data = fixture_data("webhooks/deployment_status-pending")
+    data = decoded_fixture_data("webhooks/deployment_status-pending")
 
     handler = GitHub::EventMessages::DeploymentStatus.new(data)
     response = handler.response
@@ -18,7 +18,7 @@ RSpec.describe GitHub::EventMessages::DeploymentStatus, type: :model do
   end
 
   it "returns a Slack message if the state is success" do
-    data = fixture_data("webhooks/deployment_status-success")
+    data = decoded_fixture_data("webhooks/deployment_status-success")
 
     handler = GitHub::EventMessages::DeploymentStatus.new(data)
     response = handler.response
@@ -33,7 +33,7 @@ RSpec.describe GitHub::EventMessages::DeploymentStatus, type: :model do
   end
 
   it "returns a Slack message if the status is failure" do
-    data = fixture_data("webhooks/deployment_status-failure")
+    data = decoded_fixture_data("webhooks/deployment_status-failure")
 
     handler = GitHub::EventMessages::DeploymentStatus.new(data)
     response = handler.response
@@ -48,7 +48,7 @@ RSpec.describe GitHub::EventMessages::DeploymentStatus, type: :model do
   end
 
   it "returns a Slack message if they deployed ref is a full sha" do
-    data = fixture_data("webhooks/deployment_status-full-ref")
+    data = decoded_fixture_data("webhooks/deployment_status-full-ref")
 
     handler = GitHub::EventMessages::DeploymentStatus.new(data)
     response = handler.response

--- a/spec/models/git_hub/event_messages/ping_spec.rb
+++ b/spec/models/git_hub/event_messages/ping_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GitHub::EventMessages::Ping, type: :model do
     org = team.organizations.create(name: "heroku", webhook_id: 42)
     expect(org).to be_valid
 
-    data = fixture_data("webhooks/ping")
+    data = decoded_fixture_data("webhooks/ping")
 
     handler = GitHub::EventMessages::Ping.new(data)
 

--- a/spec/models/git_hub/event_messages/pull_request_spec.rb
+++ b/spec/models/git_hub/event_messages/pull_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GitHub::EventMessages::PullRequest, type: :model do
   let(:team) { SlackHQ::Team.from_omniauth(slack_omniauth_hash_for_atmos) }
 
   it "returns a Slack message for pull request opened" do
-    data = fixture_data("webhooks/pull_request-opened")
+    data = decoded_fixture_data("webhooks/pull_request-opened")
 
     handler = GitHub::EventMessages::PullRequest.new(data)
     response = handler.response
@@ -25,7 +25,7 @@ RSpec.describe GitHub::EventMessages::PullRequest, type: :model do
   end
 
   it "returns the right Slack message when pull request merged" do
-    data = fixture_data("webhooks/pull_request-merged")
+    data = decoded_fixture_data("webhooks/pull_request-merged")
 
     handler = GitHub::EventMessages::PullRequest.new(data)
     response = handler.response

--- a/spec/models/git_hub/event_messages/push_spec.rb
+++ b/spec/models/git_hub/event_messages/push_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe GitHub::EventMessages::Push, type: :model do
   it "creates a push Slack Message" do
-    data = fixture_data("webhooks/push-1-commit")
+    data = decoded_fixture_data("webhooks/push-1-commit")
 
     handler = GitHub::EventMessages::Push.new(data)
 
@@ -19,7 +19,7 @@ RSpec.describe GitHub::EventMessages::Push, type: :model do
   end
 
   it "uses plural form when multiple commits" do
-    data = fixture_data("webhooks/push-2-commits")
+    data = decoded_fixture_data("webhooks/push-2-commits")
 
     handler = GitHub::EventMessages::Push.new(data)
 

--- a/spec/models/git_hub/event_messages/status_spec.rb
+++ b/spec/models/git_hub/event_messages/status_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe GitHub::EventMessages::Status, type: :model do
   it "returns nil if the status is pending" do
-    data = fixture_data("webhooks/status-travis-pending")
+    data = decoded_fixture_data("webhooks/status-travis-pending")
 
     handler = GitHub::EventMessages::Status.new(data)
     expect(handler.response).to be_nil
   end
 
   it "returns a Slack message for travis if the status is success" do
-    data = fixture_data("webhooks/status-travis-success")
+    data = decoded_fixture_data("webhooks/status-travis-success")
 
     handler = GitHub::EventMessages::Status.new(data)
     response = handler.response
@@ -30,7 +30,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
   end
 
   it "returns a Slack message for travis if the status is failure" do
-    data = fixture_data("webhooks/status-travis-failure")
+    data = decoded_fixture_data("webhooks/status-travis-failure")
 
     handler = GitHub::EventMessages::Status.new(data)
     response = handler.response
@@ -50,7 +50,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
   end
 
   it "returns a Slack message for circleci if the status is success" do
-    data = fixture_data("webhooks/status-circle-success")
+    data = decoded_fixture_data("webhooks/status-circle-success")
 
     handler = GitHub::EventMessages::Status.new(data)
     response = handler.response
@@ -72,7 +72,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
   end
 
   it "returns a Slack message for circle if the status is failure" do
-    data = fixture_data("webhooks/status-circle-failure")
+    data = decoded_fixture_data("webhooks/status-circle-failure")
 
     handler = GitHub::EventMessages::Status.new(data)
     response = handler.response
@@ -93,7 +93,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
   end
 
   it "returns a Slack message for changeling if the status is successful" do
-    data = fixture_data("webhooks/status-changeling-success")
+    data = decoded_fixture_data("webhooks/status-changeling-success")
 
     handler = GitHub::EventMessages::Status.new(data)
     response = handler.response
@@ -114,7 +114,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
   end
 
   it "returns a Slack message for fork repos without branch references" do
-    data = fixture_data("webhooks/status-changeling-success-fork")
+    data = decoded_fixture_data("webhooks/status-changeling-success-fork")
 
     handler = GitHub::EventMessages::Status.new(data)
     response = handler.response


### PR DESCRIPTION
Fixes a bug with statuses that don't have a commit author and move the json parsing up in the calls.