### PR TITLE
Auth to slack

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
 worker: /usr/bin/env LIBRATO_AUTORUN=1 bundle exec sidekiq
-#release: rake db:migrate
+release: rake db:migrate

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
 worker: /usr/bin/env LIBRATO_AUTORUN=1 bundle exec sidekiq
-release: rake db:migrate
+#release: rake db:migrate

--- a/app.json
+++ b/app.json
@@ -19,6 +19,9 @@
     "GITHUB_OAUTH_SECRET": {
       "description": "The GitHub OAuth client secret for being an OAuth consumer"
     },
+    "HOSTNAME": {
+      "description": "The FQDN that the server is running at"
+    },
     "RACK_ENV": {
       "description": "The rack environment used to differentiate production from staging in rollbar",
       "default": "production"

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,12 +2,16 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
+  def boomtown
+    raise("Intentional exception from the web app")
+  end
+
   def health
     render json: { name: "speakerboxxx/the-love-below" }, status: :ok
   end
 
-  def boomtown
-    raise("Intentional exception from the web app")
+  def install
+    redirect_to "/auth/slack?scope=identify,commands,bot"
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   end
 
   def install
-    redirect_to "/auth/slack?scope=identify,commands,bot"
+    redirect_to "/auth/slack_install"
   end
 
   private

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,14 +13,15 @@ class SessionsController < ApplicationController
     redirect_to "/auth/slack?origin=#{omniauth_origin}"
   end
 
-  def redis
-    @redis ||= Redis.new
+  def create_slack
+    user = SlackHQ::User.from_omniauth(omniauth_info)
+
+    session[:user_id] = user.id
+    redirect_to "/auth/github"
   end
 
-  def create_slack
+  def install_slack
     team = SlackHQ::Team.from_omniauth(omniauth_info)
-
-    redis.set "omniauth-info", omniauth_info.to_json
 
     user = team.users.find_or_initialize_by(
       slack_user_id: omniauth_info_user_id

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,8 +13,14 @@ class SessionsController < ApplicationController
     redirect_to "/auth/slack?origin=#{omniauth_origin}"
   end
 
+  def redis
+    @redis ||= Redis.new
+  end
+
   def create_slack
     team = SlackHQ::Team.from_omniauth(omniauth_info)
+
+    redis.set "omniauth-info", omniauth_info.to_json
 
     user = team.users.find_or_initialize_by(
       slack_user_id: omniauth_info_user_id

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -27,7 +27,7 @@
       <li>Use chat to route to specific rooms.</li>
     </ul>
     <p class="download">
-      <a href="/auth/slack" class="button">Install Speakerboxxx for Slack</a>
+      <a href="/install" class="button">Install Speakerboxxx for Slack</a>
     </p>
 
     <img class="screenshot" alt="ChatOps with Slack, GitHub, and Heroku" src="https://cloud.githubusercontent.com/assets/416727/15088524/336bee40-13aa-11e6-9cf2-707232754ac3.png" />

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,6 +3,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identify"
+  provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identity.basic"
   provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identify,commands,bot", name: :slack_install
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,6 +3,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identity.basic"
+  provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identity.basic,users:read"
   provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identify,commands,bot", name: :slack_install
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -4,4 +4,5 @@ end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identify"
+  provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identify,commands,bot", name: :slack_install
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,5 +3,5 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identify,commands,bot"
+  provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identify"
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -3,6 +3,6 @@ Rails.application.config.middleware.use OmniAuth::Builder do
 end
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identity.basic,users:read"
+  provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identity.basic"
   provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identify,commands,bot", name: :slack_install
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   get  "/auth/failure",                to: "sessions#destroy"
   get  "/auth/github/callback",        to: "sessions#create_github"
   get  "/auth/slack/callback",         to: "sessions#create_slack"
-  get  "/auth/slack_install/callback", to: "sessions#create_slack"
+  get  "/auth/slack_install/callback", to: "sessions#install_slack"
 
   post "/signout",  to: "sessions#destroy"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,20 +1,20 @@
 Rails.application.routes.draw do
-
   mount Peek::Railtie => "/peek"
 
   get  "/auth/failure",         to: "sessions#destroy"
   get  "/auth/github/callback", to: "sessions#create_github"
   get  "/auth/slack/callback",  to: "sessions#create_slack"
+  post "/signout",  to: "sessions#destroy"
 
-  get "/health", to: "application#health"
+  get "/health",   to: "application#health"
+  get "/install",  to: "application#install"
   get "/boomtown", to: "application#boomtown"
 
-  get "/support", to: "pages#support"
+  get "/support",  to: "pages#support"
 
   post "/webhooks/:team_id/github/:org_name", to: "webhooks#create"
 
   post "/commands", to: "commands#create"
-  post "/signout", to: "sessions#destroy"
 
   root to: "pages#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,11 @@
 Rails.application.routes.draw do
   mount Peek::Railtie => "/peek"
 
-  get  "/auth/failure",         to: "sessions#destroy"
-  get  "/auth/github/callback", to: "sessions#create_github"
-  get  "/auth/slack/callback",  to: "sessions#create_slack"
+  get  "/auth/failure",                to: "sessions#destroy"
+  get  "/auth/github/callback",        to: "sessions#create_github"
+  get  "/auth/slack/callback",         to: "sessions#create_slack"
+  get  "/auth/slack_install/callback", to: "sessions#create_slack"
+
   post "/signout",  to: "sessions#destroy"
 
   get "/health",   to: "application#health"

--- a/spec/fixtures/slack.com/identity.json
+++ b/spec/fixtures/slack.com/identity.json
@@ -1,0 +1,10 @@
+{
+  "ok":true,
+  "user":{
+    "name":"Toolskai",
+    "id":"U1RM9BNL8"
+  },
+  "team":{
+    "id":"T092F92CG"
+  }
+}

--- a/spec/request/install_spec.rb
+++ b/spec/request/install_spec.rb
@@ -1,17 +1,32 @@
 require "rails_helper"
 
 RSpec.describe "Speakerboxxx GET /auth/slack/callback", type: :request do
-  before do
+  it "creates a user on the organization when authenticated" do
     OmniAuth.config.mock_auth[:slack] = slack_omniauth_hash_for_atmos
-  end
-
-  it "sends you back to your chat via HTTPS after authenticating" do
     expect do
       get "/auth/slack"
       expect(status).to eql(302)
       uri = Addressable::URI.parse(headers["Location"])
       expect(uri.host).to eql("www.example.com")
       expect(uri.path).to eql("/auth/slack/callback")
+      follow_redirect!
+    end.to change { SlackHQ::Team.count }.by(1)
+
+    team = SlackHQ::Team.first
+    user = team.users.first
+
+    expect(user.slack_user_name).to eql("atmos")
+    expect(team.bot_token).to eql("xoxo-hugs-n-kisses")
+  end
+
+  it "creates a user and stores a token on the organization when installed" do
+    OmniAuth.config.mock_auth[:slack_install] = slack_omniauth_hash_for_atmos
+    expect do
+      get "/auth/slack_install"
+      expect(status).to eql(302)
+      uri = Addressable::URI.parse(headers["Location"])
+      expect(uri.host).to eql("www.example.com")
+      expect(uri.path).to eql("/auth/slack_install/callback")
       follow_redirect!
     end.to change { SlackHQ::Team.count }.by(1)
 

--- a/spec/request/install_spec.rb
+++ b/spec/request/install_spec.rb
@@ -2,7 +2,16 @@ require "rails_helper"
 
 RSpec.describe "Speakerboxxx GET /auth/slack/callback", type: :request do
   it "creates a user on the organization when authenticated" do
-    OmniAuth.config.mock_auth[:slack] = slack_omniauth_hash_for_atmos
+    token = "xoxp-9101111159-5657146422-59735495733-3186a13efg"
+    stub_json_request(:get,
+                      "https://slack.com/api/users.identity?token=#{token}",
+                      fixture_data("slack.com/identity"))
+
+    SlackHQ::Team.create(team_id: "T092F92CG",
+                         bot_user_id: "U9MG9BRL6",
+                         bot_token: "xoxo-woop-woop")
+
+    OmniAuth.config.mock_auth[:slack] = slack_omniauth_hash_for_toolskai
     expect do
       get "/auth/slack"
       expect(status).to eql(302)
@@ -10,13 +19,12 @@ RSpec.describe "Speakerboxxx GET /auth/slack/callback", type: :request do
       expect(uri.host).to eql("www.example.com")
       expect(uri.path).to eql("/auth/slack/callback")
       follow_redirect!
-    end.to change { SlackHQ::Team.count }.by(1)
+    end.to change { SlackHQ::Team.count }.by(0)
 
     team = SlackHQ::Team.first
     user = team.users.first
 
-    expect(user.slack_user_name).to eql("atmos")
-    expect(team.bot_token).to eql("xoxo-hugs-n-kisses")
+    expect(user.slack_user_name).to eql("Toolskai")
   end
 
   it "creates a user and stores a token on the organization when installed" do

--- a/spec/request/installation_spec.rb
+++ b/spec/request/installation_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe "Speakerboxxx GET /install", type: :request do
     uri = Addressable::URI.parse(headers["Location"])
     expect(uri.host).to eql("slack.com")
     expect(uri.path).to eql("/oauth/authorize")
-    expect(uri.query_values["scope"]).to eql("identity.basic")
+    expect(uri.query_values["scope"]).to eql("identity.basic,users:read")
   end
 end

--- a/spec/request/installation_spec.rb
+++ b/spec/request/installation_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Speakerboxxx GET /install", type: :request do
+  after  { OmniAuth.config.test_mode = true }
+  before { OmniAuth.config.test_mode = false }
+
+  it "sends you to slack with appropriate scopes requested to install" do
+    get "/install"
+    expect(status).to eql(302)
+    uri = Addressable::URI.parse(headers["Location"])
+    expect(uri.host).to eql("www.example.com")
+    expect(uri.path).to eql("/auth/slack_install")
+
+    follow_redirect!
+    uri = Addressable::URI.parse(headers["Location"])
+    expect(uri.host).to eql("slack.com")
+    expect(uri.path).to eql("/oauth/authorize")
+    expect(uri.query_values["scope"]).to eql("identify,commands,bot")
+  end
+  
+  it "sends you to slack with appropriate scopes requested to authenticate" do
+    get "/auth/slack"
+    expect(status).to eql(302)
+    uri = Addressable::URI.parse(headers["Location"])
+    expect(uri.host).to eql("slack.com")
+    expect(uri.path).to eql("/oauth/authorize")
+    expect(uri.query_values["scope"]).to eql("identify")
+  end
+end

--- a/spec/request/installation_spec.rb
+++ b/spec/request/installation_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Speakerboxxx GET /install", type: :request do
     expect(uri.path).to eql("/oauth/authorize")
     expect(uri.query_values["scope"]).to eql("identify,commands,bot")
   end
-  
+
   it "sends you to slack with appropriate scopes requested to authenticate" do
     get "/auth/slack"
     expect(status).to eql(302)

--- a/spec/request/installation_spec.rb
+++ b/spec/request/installation_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe "Speakerboxxx GET /install", type: :request do
     uri = Addressable::URI.parse(headers["Location"])
     expect(uri.host).to eql("slack.com")
     expect(uri.path).to eql("/oauth/authorize")
-    expect(uri.query_values["scope"]).to eql("identity.basic,users:read")
+    expect(uri.query_values["scope"]).to eql("identity.basic")
   end
 end

--- a/spec/request/installation_spec.rb
+++ b/spec/request/installation_spec.rb
@@ -24,6 +24,6 @@ RSpec.describe "Speakerboxxx GET /install", type: :request do
     uri = Addressable::URI.parse(headers["Location"])
     expect(uri.host).to eql("slack.com")
     expect(uri.path).to eql("/oauth/authorize")
-    expect(uri.query_values["scope"]).to eql("identify")
+    expect(uri.query_values["scope"]).to eql("identity.basic")
   end
 end

--- a/spec/support/omni_auth_helpers.rb
+++ b/spec/support/omni_auth_helpers.rb
@@ -40,6 +40,9 @@ module OmniAuthHelpers
       token: SecureRandom.hex(24)
     }
     extra = {
+      raw_info: {
+        ok: true
+      },
       bot_info: {
         bot_access_token: "xoxo-hugs-n-kisses",
         bot_user_id: "U421FY7"
@@ -51,6 +54,44 @@ module OmniAuthHelpers
                            info: info,
                            extra: extra,
                            credentials: credentials)
+  end
+
+  def slack_omniauth_hash_for_toolskai
+    info = {
+      provider: "slack",
+      uid: nil,
+      info: {
+      },
+      credentials: {
+        token: "xoxp-9101111159-5657146422-59735495733-3186a13efg",
+        expires: false
+      },
+      extra: {
+        raw_info: {
+          ok: false,
+          error: "missing_scope",
+          needed: "identify",
+          provided: "identity.basic"
+        },
+        web_hook_info: {
+        },
+        bot_info: {
+        },
+        user_info: {
+          ok: false,
+          error: "missing_scope",
+          needed: "users:read",
+          provided: "identity.basic"
+        },
+        team_info: {
+          ok: false,
+          error: "missing_scope",
+          needed: "team:read",
+          provided: "identity.basic"
+        }
+      }
+    }
+    OmniAuth::AuthHash.new(info)
   end
   # rubocop:enable Metrics/MethodLength
 


### PR DESCRIPTION
This fixes a bug where speakerboxxx tries to be installed repeatedly instead of just authenticating the user. We need this only to be installed by an admin and everyone else can work off of the identity oauth scope.