### PR TITLE
Don't show org names on status notifications

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,7 +48,7 @@ ModuleLength:
     - !ruby/regexp /spec\/*\/*/
 
 ClassLength:
-  Max: 120
+  Max: 125
   Exclude:
     - !ruby/regexp /spec\/*\/*/
 

--- a/app/models/git_hub/event_messages/status.rb
+++ b/app/models/git_hub/event_messages/status.rb
@@ -103,24 +103,34 @@ module GitHub::EventMessages
       end
     end
 
+    # rubocop:disable Metrics/LineLength
     def footer_icon
       case body["context"]
       when "ci/circleci"
-        "https://cloud.githubusercontent.com/assets/38/16295346/2b121e26-38db-11e6-9c4f-ee905519fdf3.png" # rubocop:disable Metrics/LineLength
+        "https://cloud.githubusercontent.com/assets/38/16295346/2b121e26-38db-11e6-9c4f-ee905519fdf3.png"
       when "continuous-integration/travis-ci/push"
-        "https://cdn.travis-ci.com/images/logos/TravisCI-Mascot-grey-ab1429c891b31bb91d29cc0b5a9758de.png" # rubocop:disable Metrics/LineLength
+        "https://cdn.travis-ci.com/images/logos/TravisCI-Mascot-grey-ab1429c891b31bb91d29cc0b5a9758de.png"
       when "heroku/compliance"
-        "https://cloud.githubusercontent.com/assets/38/16531791/ebc00ff4-3f82-11e6-919b-693a5cf9183a.png" # rubocop:disable Metrics/LineLength
+        "https://cloud.githubusercontent.com/assets/38/16531791/ebc00ff4-3f82-11e6-919b-693a5cf9183a.png"
       when "vulnerabilities/gems"
-        "https://cloud.githubusercontent.com/assets/38/16547100/e23b670e-4116-11e6-8b38-bac1b4c853f0.jpg" # rubocop:disable Metrics/LineLength
+        "https://cloud.githubusercontent.com/assets/38/16547100/e23b670e-4116-11e6-8b38-bac1b4c853f0.jpg"
       end
     end
+    # rubocop:enable Metrics/LineLength
 
     def suppressed_contexts
       %w{codeclimate continuous-integration/travis-ci/pr vulnerabilities/gems}
     end
 
-    # rubocop:disable Metrics/AbcSize
+    def attachment_text
+      "<#{repo_url}|#{repo_name}> build of <#{branch_url}|#{branch_ref}> " \
+        "#{state_description}. <#{target_url}|Details>"
+    end
+
+    def fallback_text
+      "#{repo_name} build of #{branch} was #{state_description}"
+    end
+
     def response
       return if body["state"] == "pending"
       return if suppressed_contexts.include?(body["context"])
@@ -128,9 +138,9 @@ module GitHub::EventMessages
         channel: "#notifications",
         attachments: [
           {
-            fallback: "#{full_name} build of #{branch} was #{state_description}", # rubocop:disable Metrics/LineLength
+            fallback: fallback_text,
             color: message_color,
-            text: "<#{repo_url}|#{full_name}> build of <#{branch_url}|#{branch_ref}> #{state_description}. <#{target_url}|Details>", # rubocop:disable Metrics/LineLength
+            text: attachment_text,
             footer: footer_text,
             footer_icon: footer_icon,
             mrkdwn_in: [:text, :pretext]
@@ -138,6 +148,5 @@ module GitHub::EventMessages
         ]
       }
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/spec/fixtures/webhooks/status-changeling-success-fork.json
+++ b/spec/fixtures/webhooks/status-changeling-success-fork.json
@@ -82,10 +82,10 @@
   "updated_at": "2016-07-01T18:59:23Z",
   "repository": {
     "id": 3287486,
-    "name": "api",
+    "name": "speakerboxxx",
     "full_name": "atmos-org/speakerboxxx",
     "owner": {
-      "login": "heroku",
+      "login": "atmos-org",
       "id": 23211,
       "avatar_url": "https://avatars.githubusercontent.com/u/23211?v=3",
       "gravatar_id": "",

--- a/spec/fixtures/webhooks/status-changeling-success.json
+++ b/spec/fixtures/webhooks/status-changeling-success.json
@@ -89,10 +89,10 @@
   "updated_at": "2016-07-01T18:59:23Z",
   "repository": {
     "id": 3287486,
-    "name": "api",
+    "name": "speakerboxxx",
     "full_name": "atmos-org/speakerboxxx",
     "owner": {
-      "login": "heroku",
+      "login": "atmos-org",
       "id": 23211,
       "avatar_url": "https://avatars.githubusercontent.com/u/23211?v=3",
       "gravatar_id": "",

--- a/spec/models/git_hub/event_messages/status_spec.rb
+++ b/spec/models/git_hub/event_messages/status_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     attachments = response[:attachments]
     expect(attachments.first[:fallback]).to_not be_nil
     expect(attachments.first[:color]).to eql("#36a64f")
-    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|atmos-org/speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master@7dcf6ad3> was successful. <https://travis-ci.com/atmos-org/speakerboxxx/builds/26768873|Details>") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master@7dcf6ad3> was successful. <https://travis-ci.com/atmos-org/speakerboxxx/builds/26768873|Details>") # rubocop:disable Metrics/LineLength
 
     fields = attachments.first[:fields]
     expect(fields).to be_nil
@@ -39,7 +39,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     attachments = response[:attachments]
     expect(attachments.first[:fallback]).to_not be_nil
     expect(attachments.first[:color]).to eql("#f00")
-    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|atmos-org/speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/add-pull-requests|add-pull-requests@89bfabcc> failed. <https://travis-ci.com/atmos-org/speakerboxxx/builds/26834904|Details>") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/add-pull-requests|add-pull-requests@89bfabcc> failed. <https://travis-ci.com/atmos-org/speakerboxxx/builds/26834904|Details>") # rubocop:disable Metrics/LineLength
 
     fields = attachments.first[:fields]
     expect(fields).to be_nil
@@ -61,7 +61,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     attachments = response[:attachments]
     expect(attachments.first[:fallback]).to_not be_nil
     expect(attachments.first[:color]).to eql("#36a64f")
-    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|atmos-org/speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master@a2df354c> was successful. <https://circleci.com/gh/atmos-org/speakerboxxx/1|Details>") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master@a2df354c> was successful. <https://circleci.com/gh/atmos-org/speakerboxxx/1|Details>") # rubocop:disable Metrics/LineLength
 
     fields = attachments.first[:fields]
     expect(fields).to be_nil
@@ -82,7 +82,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     attachments = response[:attachments]
     expect(attachments.first[:fallback]).to_not be_nil
     expect(attachments.first[:color]).to eql("#f00")
-    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|atmos-org/speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master@a2df354c> failed. <https://circleci.com/gh/atmos-org/speakerboxxx/1|Details>") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master@a2df354c> failed. <https://circleci.com/gh/atmos-org/speakerboxxx/1|Details>") # rubocop:disable Metrics/LineLength
 
     fields = attachments.first[:fields]
     expect(fields).to be_nil
@@ -103,7 +103,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     attachments = response[:attachments]
     expect(attachments.first[:fallback]).to_not be_nil
     expect(attachments.first[:color]).to eql("#36a64f")
-    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|atmos-org/speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/endpoint-events|endpoint-events@46afb288> was successful. <https://changeling.heroku.tools/multipasses/4689e051-468a-4c09-8cdc-2958e1558f01|Details>") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/endpoint-events|endpoint-events@46afb288> was successful. <https://changeling.heroku.tools/multipasses/4689e051-468a-4c09-8cdc-2958e1558f01|Details>") # rubocop:disable Metrics/LineLength
 
     fields = attachments.first[:fields]
     expect(fields).to be_nil
@@ -124,7 +124,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     attachments = response[:attachments]
     expect(attachments.first[:fallback]).to_not be_nil
     expect(attachments.first[:color]).to eql("#36a64f")
-    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|atmos-org/speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/46afb288|46afb288> was successful. <https://changeling.heroku.tools/multipasses/4689e051-468a-4c09-8cdc-2958e1558f01|Details>") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/46afb288|46afb288> was successful. <https://changeling.heroku.tools/multipasses/4689e051-468a-4c09-8cdc-2958e1558f01|Details>") # rubocop:disable Metrics/LineLength
 
     fields = attachments.first[:fields]
     expect(fields).to be_nil


### PR DESCRIPTION
# Before

![notifications atmos dot org slack 2016-07-19 17-25-52](https://cloud.githubusercontent.com/assets/38/16971121/e4910d62-4dd5-11e6-9b55-305d5c2722ea.png)

# After

![notifications atmos dot org slack 2016-07-19 17-26-51](https://cloud.githubusercontent.com/assets/38/16971133/ffd26e54-4dd5-11e6-9131-118edb54cd30.png)
