### PR TITLE
Respond to in-channel deployment requests

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -36,7 +36,7 @@ class WebhookJob < ApplicationJob
       if event_type == "deployment_status" && handler.chat_deployment?
         chat_channel = handler.chat_deployment_room
         if chat_channel != channel
-          response[:channel] = chat_channel
+          response[:channel] = "##{chat_channel}"
           team.bot.chat_postMessage(response)
         end
       end

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -3,6 +3,8 @@ class WebhookJob < ApplicationJob
   queue_as :default
 
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def perform(*args)
     team_id = args.first.fetch(:team_id)
     team = SlackHQ::Team.find_by(team_id: team_id)
@@ -25,10 +27,18 @@ class WebhookJob < ApplicationJob
     handler = GitHub::EventMessages.handler_for(event_type, JSON.load(body))
     if handler && handler.response
       response = handler.response
-      response[:channel] = org.default_room_for(handler.repo_name)
+      channel  = org.default_room_for(handler.repo_name)
 
+      response[:channel] = channel
       team.bot.chat_postMessage(response)
+
+      if event_type == "deployment_status" && handler.chat_deployment?
+        chat_channel = handler.chat_deployment_room
+        team.bot.chat_postMessage(response) unless chat_channel == channel
+      end
     end
   end
+  # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/AbcSize
 end

--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -3,6 +3,7 @@ class WebhookJob < ApplicationJob
   queue_as :default
 
   # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
   def perform(*args)
@@ -34,11 +35,15 @@ class WebhookJob < ApplicationJob
 
       if event_type == "deployment_status" && handler.chat_deployment?
         chat_channel = handler.chat_deployment_room
-        team.bot.chat_postMessage(response) unless chat_channel == channel
+        if chat_channel != channel
+          response[:channel] = chat_channel
+          team.bot.chat_postMessage(response)
+        end
       end
     end
   end
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity
+  # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
 end

--- a/app/models/git_hub/event_messages/deployment_status.rb
+++ b/app/models/git_hub/event_messages/deployment_status.rb
@@ -135,7 +135,8 @@ module GitHub::EventMessages
     def chat_deployment_room
       deployment_payload &&
         deployment_payload["notify"] &&
-        deployment_payload["notify"]["room"]
+        deployment_payload["notify"]["room"] &&
+        deployment_payload["notify"]["room"].sub(/^#/, "")
     end
   end
 end

--- a/app/models/git_hub/event_messages/deployment_status.rb
+++ b/app/models/git_hub/event_messages/deployment_status.rb
@@ -14,16 +14,28 @@ module GitHub::EventMessages
       body["repository"]["full_name"]
     end
 
+    def deployment
+      body["deployment"]
+    end
+
+    def deployment_payload
+      body["deployment"]["payload"]
+    end
+
+    def deployment_status
+      body["deployment_status"]
+    end
+
     def branch
-      if body["deployment"]["ref"] == body["deployment"]["sha"]
+      if deployment["ref"] == deployment["sha"]
         short_sha
       else
-        body["deployment"]["ref"]
+        deployment["ref"]
       end
     end
 
     def target_url
-      body["deployment_status"]["target_url"]
+      deployment_status["target_url"]
     end
 
     def sha_url
@@ -39,11 +51,11 @@ module GitHub::EventMessages
     end
 
     def short_sha
-      body["deployment"]["sha"][0..7]
+      deployment["sha"][0..7]
     end
 
     def author
-      body["deployment"]["creator"]["login"]
+      deployment["creator"]["login"]
     end
 
     def author_url
@@ -51,7 +63,7 @@ module GitHub::EventMessages
     end
 
     def environment
-      body["deployment"]["environment"]
+      deployment["environment"]
     end
 
     def environment_url
@@ -59,8 +71,8 @@ module GitHub::EventMessages
     end
 
     def duration
-      (Time.zone.parse(body["deployment_status"]["created_at"]) -
-        Time.zone.parse(body["deployment"]["created_at"])).round
+      (Time.zone.parse(deployment_status["created_at"]) -
+        Time.zone.parse(deployment["created_at"])).round
     end
 
     def message_color
@@ -114,6 +126,16 @@ module GitHub::EventMessages
           }
         ]
       }
+    end
+
+    def chat_deployment?
+      !chat_deployment_room.nil?
+    end
+
+    def chat_deployment_room
+      deployment_payload &&
+        deployment_payload["notify"] &&
+        deployment_payload["notify"]["room"]
     end
   end
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -6,3 +6,5 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identity.basic"
   provider :slack, ENV["SLACK_OAUTH_ID"], ENV["SLACK_OAUTH_SECRET"], scope: "identify,commands,bot", name: :slack_install
 end
+
+OmniAuth.config.logger = Rails.logger

--- a/spec/fixtures/webhooks/deployment_status-failure.json
+++ b/spec/fixtures/webhooks/deployment_status-failure.json
@@ -36,12 +36,6 @@
     "ref": "master",
     "task": "deploy",
     "payload": {
-      "notify": {
-        "room": "general",
-        "user": "U0YJYFQ4E",
-        "team_id": "T0YJVLHHA",
-        "user_name": "atmos"
-      },
       "name": "speakerboxxx",
       "pipeline": {
         "id": "189f8d58-cb8b-47e9-a7a0-b9378ef0b865",

--- a/spec/fixtures/webhooks/deployment_status-pending-chat.json
+++ b/spec/fixtures/webhooks/deployment_status-pending-chat.json
@@ -36,6 +36,12 @@
     "ref": "master",
     "task": "deploy",
     "payload": {
+      "notify": {
+        "room": "general",
+        "user": "U0YJYFQ4E",
+        "team_id": "T0YJVLHHA",
+        "user_name": "atmos"
+      },
       "name": "speakerboxxx",
       "pipeline": {
         "id": "189f8d58-cb8b-47e9-a7a0-b9378ef0b865",

--- a/spec/fixtures/webhooks/deployment_status-success.json
+++ b/spec/fixtures/webhooks/deployment_status-success.json
@@ -36,12 +36,6 @@
     "ref": "master",
     "task": "deploy",
     "payload": {
-      "notify": {
-        "room": "general",
-        "user": "U0YJYFQ4E",
-        "team_id": "T0YJVLHHA",
-        "user_name": "atmos"
-      },
       "name": "speakerboxxx",
       "pipeline": {
         "id": "189f8d58-cb8b-47e9-a7a0-b9378ef0b865",

--- a/spec/models/git_hub/event_messages/deployment_status_spec.rb
+++ b/spec/models/git_hub/event_messages/deployment_status_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe GitHub::EventMessages::DeploymentStatus, type: :model do
     data = decoded_fixture_data("webhooks/deployment_status-pending")
 
     handler = GitHub::EventMessages::DeploymentStatus.new(data)
+    expect(handler).to_not be_chat_deployment
     response = handler.response
     expect(response).to_not be_nil
     expect(response[:channel]).to eql("#notifications")
@@ -21,6 +22,7 @@ RSpec.describe GitHub::EventMessages::DeploymentStatus, type: :model do
     data = decoded_fixture_data("webhooks/deployment_status-success")
 
     handler = GitHub::EventMessages::DeploymentStatus.new(data)
+    expect(handler).to_not be_chat_deployment
     response = handler.response
     expect(response).to_not be_nil
     expect(response[:channel]).to eql("#notifications")
@@ -36,6 +38,7 @@ RSpec.describe GitHub::EventMessages::DeploymentStatus, type: :model do
     data = decoded_fixture_data("webhooks/deployment_status-failure")
 
     handler = GitHub::EventMessages::DeploymentStatus.new(data)
+    expect(handler).to_not be_chat_deployment
     response = handler.response
     expect(response).to_not be_nil
     expect(response[:channel]).to eql("#notifications")
@@ -51,6 +54,7 @@ RSpec.describe GitHub::EventMessages::DeploymentStatus, type: :model do
     data = decoded_fixture_data("webhooks/deployment_status-full-ref")
 
     handler = GitHub::EventMessages::DeploymentStatus.new(data)
+    expect(handler).to_not be_chat_deployment
     response = handler.response
     expect(response).to_not be_nil
     expect(response[:channel]).to eql("#notifications")
@@ -60,6 +64,23 @@ RSpec.describe GitHub::EventMessages::DeploymentStatus, type: :model do
       .to eql("<https://github.com/atmos|atmos>'s <https://dashboard.heroku.com/apps/speakerboxxx-production/activity/builds/96d42bc6-4461-49d2-be08-0208531728c4|production> deployment of <https://github.com/atmos-org/speakerboxxx/tree/923821e5|speakerboxxx/923821e5> failed. 31s")
     expect(attachments.first[:fallback])
       .to eql("atmos's production deployment of speakerboxxx/923821e5 failed. 31s")
+  end
+
+  it "can identify and route chat initiated deployments" do
+    data = decoded_fixture_data("webhooks/deployment_status-pending-chat")
+
+    handler = GitHub::EventMessages::DeploymentStatus.new(data)
+    expect(handler).to be_chat_deployment
+    expect(handler.chat_deployment_room).to eql("general")
+    response = handler.response
+    expect(response).to_not be_nil
+    expect(response[:channel]).to eql("#notifications")
+    attachments = response[:attachments]
+    expect(attachments.first[:color]).to eql("#c0c0c0")
+    expect(attachments.first[:text])
+      .to eql("<https://github.com/atmos|atmos> is deploying <https://github.com/atmos-org/speakerboxxx/tree/923821e5|speakerboxxx/master> to <https://dashboard.heroku.com/apps/speakerboxxx-production/activity/builds/96d42bc6-4461-49d2-be08-0208531728c4|production>.")
+    expect(attachments.first[:fallback])
+      .to eql("atmos is deploying speakerboxxx/master to production.")
   end
 end
 # rubocop:enable Metrics/LineLength


### PR DESCRIPTION
If you're using github deployments and have a "notify" field on your deployment payload we can do deployment messages in the default room and the one that triggered it.