### PR TITLE
Less noisy statuses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,7 +48,7 @@ ModuleLength:
     - !ruby/regexp /spec\/*\/*/
 
 ClassLength:
-  Max: 125
+  Max: 130
   Exclude:
     - !ruby/regexp /spec\/*\/*/
 

--- a/app/models/git_hub/event_messages/deployment_status.rb
+++ b/app/models/git_hub/event_messages/deployment_status.rb
@@ -1,6 +1,5 @@
 module GitHub::EventMessages
   # Class to generate Slack Messages based on a GitHub DeploymentStatus Webhook
-  # rubocop:disable Metrics/ClassLength
   class DeploymentStatus
     attr_accessor :body
     def initialize(body)
@@ -157,5 +156,4 @@ module GitHub::EventMessages
         deployment_payload["notify"]["room"].sub(/^#/, "")
     end
   end
-  # rubocop:enable Metrics/ClassLength
 end

--- a/app/models/git_hub/event_messages/status.rb
+++ b/app/models/git_hub/event_messages/status.rb
@@ -30,7 +30,7 @@ module GitHub::EventMessages
       if short_sha == branch
         short_sha
       else
-        "#{branch}@#{short_sha}"
+        branch
       end
     end
 
@@ -86,18 +86,22 @@ module GitHub::EventMessages
       when "web-flow"
         ""
       else
-        " on behalf of #{actor}"
+        " for #{actor}"
       end
+    end
+
+    def changeling_description
+      body["description"].gsub("All requirements completed. ", "")
     end
 
     def footer_text
       case body["context"]
       when "ci/circleci"
-        "circle-ci#{actor_description}"
+        "circle-ci built #{short_sha}#{actor_description}"
       when "continuous-integration/travis-ci/push"
-        "Travis-CI#{actor_description}"
+        "Travis-CI built #{short_sha}#{actor_description}"
       when "heroku/compliance"
-        "Changeling: #{body['description']}"
+        "Changeling: #{changeling_description}"
       else
         "Unknown"
       end

--- a/spec/models/git_hub/event_messages/status_spec.rb
+++ b/spec/models/git_hub/event_messages/status_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     attachments = response[:attachments]
     expect(attachments.first[:fallback]).to_not be_nil
     expect(attachments.first[:color]).to eql("#36a64f")
-    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master@7dcf6ad3> was successful. <https://travis-ci.com/atmos-org/speakerboxxx/builds/26768873|Details>") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master> was successful. <https://travis-ci.com/atmos-org/speakerboxxx/builds/26768873|Details>") # rubocop:disable Metrics/LineLength
 
     fields = attachments.first[:fields]
     expect(fields).to be_nil
 
-    expect(attachments.first[:footer]).to eql("Travis-CI on behalf of atmos")
+    expect(attachments.first[:footer]).to eql("Travis-CI built 7dcf6ad3 for atmos")
     expect(attachments.first[:footer_icon]).to eql("https://cdn.travis-ci.com/images/logos/TravisCI-Mascot-grey-ab1429c891b31bb91d29cc0b5a9758de.png") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:mrkdwn_in]).to eql([:text, :pretext])
   end
@@ -39,12 +39,12 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     attachments = response[:attachments]
     expect(attachments.first[:fallback]).to_not be_nil
     expect(attachments.first[:color]).to eql("#f00")
-    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/add-pull-requests|add-pull-requests@89bfabcc> failed. <https://travis-ci.com/atmos-org/speakerboxxx/builds/26834904|Details>") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/add-pull-requests|add-pull-requests> failed. <https://travis-ci.com/atmos-org/speakerboxxx/builds/26834904|Details>") # rubocop:disable Metrics/LineLength
 
     fields = attachments.first[:fields]
     expect(fields).to be_nil
 
-    expect(attachments.first[:footer]).to eql("Travis-CI on behalf of atmos")
+    expect(attachments.first[:footer]).to eql("Travis-CI built 89bfabcc for atmos")
     expect(attachments.first[:footer_icon]).to eql("https://cdn.travis-ci.com/images/logos/TravisCI-Mascot-grey-ab1429c891b31bb91d29cc0b5a9758de.png") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:mrkdwn_in]).to eql([:text, :pretext])
   end
@@ -61,12 +61,12 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     attachments = response[:attachments]
     expect(attachments.first[:fallback]).to_not be_nil
     expect(attachments.first[:color]).to eql("#36a64f")
-    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master@a2df354c> was successful. <https://circleci.com/gh/atmos-org/speakerboxxx/1|Details>") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master> was successful. <https://circleci.com/gh/atmos-org/speakerboxxx/1|Details>") # rubocop:disable Metrics/LineLength
 
     fields = attachments.first[:fields]
     expect(fields).to be_nil
 
-    expect(attachments.first[:footer]).to eql("circle-ci")
+    expect(attachments.first[:footer]).to eql("circle-ci built a2df354c")
     expect(attachments.first[:footer_icon]).to eql("https://cloud.githubusercontent.com/assets/38/16295346/2b121e26-38db-11e6-9c4f-ee905519fdf3.png") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:mrkdwn_in]).to eql([:text, :pretext])
   end
@@ -82,12 +82,12 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     attachments = response[:attachments]
     expect(attachments.first[:fallback]).to_not be_nil
     expect(attachments.first[:color]).to eql("#f00")
-    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master@a2df354c> failed. <https://circleci.com/gh/atmos-org/speakerboxxx/1|Details>") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/master|master> failed. <https://circleci.com/gh/atmos-org/speakerboxxx/1|Details>") # rubocop:disable Metrics/LineLength
 
     fields = attachments.first[:fields]
     expect(fields).to be_nil
 
-    expect(attachments.first[:footer]).to eql("circle-ci")
+    expect(attachments.first[:footer]).to eql("circle-ci built a2df354c")
     expect(attachments.first[:footer_icon]).to eql("https://cloud.githubusercontent.com/assets/38/16295346/2b121e26-38db-11e6-9c4f-ee905519fdf3.png") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:mrkdwn_in]).to eql([:text, :pretext])
   end
@@ -103,12 +103,12 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     attachments = response[:attachments]
     expect(attachments.first[:fallback]).to_not be_nil
     expect(attachments.first[:color]).to eql("#36a64f")
-    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/endpoint-events|endpoint-events@46afb288> was successful. <https://changeling.heroku.tools/multipasses/4689e051-468a-4c09-8cdc-2958e1558f01|Details>") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:text]).to eql("<https://github.com/atmos-org/speakerboxxx|speakerboxxx> build of <https://github.com/atmos-org/speakerboxxx/tree/endpoint-events|endpoint-events> was successful. <https://changeling.heroku.tools/multipasses/4689e051-468a-4c09-8cdc-2958e1558f01|Details>") # rubocop:disable Metrics/LineLength
 
     fields = attachments.first[:fields]
     expect(fields).to be_nil
 
-    expect(attachments.first[:footer]).to eql("Changeling: All requirements completed. Reviewed by dmcinnes.") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:footer]).to eql("Changeling: Reviewed by dmcinnes.") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:footer_icon]).to eql("https://cloud.githubusercontent.com/assets/38/16531791/ebc00ff4-3f82-11e6-919b-693a5cf9183a.png") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:mrkdwn_in]).to eql([:text, :pretext])
   end
@@ -129,7 +129,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     fields = attachments.first[:fields]
     expect(fields).to be_nil
 
-    expect(attachments.first[:footer]).to eql("Changeling: All requirements completed. Reviewed by dmcinnes.") # rubocop:disable Metrics/LineLength
+    expect(attachments.first[:footer]).to eql("Changeling: Reviewed by dmcinnes.") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:footer_icon]).to eql("https://cloud.githubusercontent.com/assets/38/16531791/ebc00ff4-3f82-11e6-919b-693a5cf9183a.png") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:mrkdwn_in]).to eql([:text, :pretext])
   end

--- a/spec/models/git_hub/event_messages/status_spec.rb
+++ b/spec/models/git_hub/event_messages/status_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     fields = attachments.first[:fields]
     expect(fields).to be_nil
 
-    expect(attachments.first[:footer]).to eql("Travis-CI built 7dcf6ad3 for atmos")
+    expect(attachments.first[:footer]).to eql("Travis-CI built 7dcf6ad3 for atmos") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:footer_icon]).to eql("https://cdn.travis-ci.com/images/logos/TravisCI-Mascot-grey-ab1429c891b31bb91d29cc0b5a9758de.png") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:mrkdwn_in]).to eql([:text, :pretext])
   end
@@ -44,7 +44,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     fields = attachments.first[:fields]
     expect(fields).to be_nil
 
-    expect(attachments.first[:footer]).to eql("Travis-CI built 89bfabcc for atmos")
+    expect(attachments.first[:footer]).to eql("Travis-CI built 89bfabcc for atmos") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:footer_icon]).to eql("https://cdn.travis-ci.com/images/logos/TravisCI-Mascot-grey-ab1429c891b31bb91d29cc0b5a9758de.png") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:mrkdwn_in]).to eql([:text, :pretext])
   end
@@ -66,7 +66,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     fields = attachments.first[:fields]
     expect(fields).to be_nil
 
-    expect(attachments.first[:footer]).to eql("circle-ci built a2df354c")
+    expect(attachments.first[:footer]).to eql("circle-ci built a2df354c") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:footer_icon]).to eql("https://cloud.githubusercontent.com/assets/38/16295346/2b121e26-38db-11e6-9c4f-ee905519fdf3.png") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:mrkdwn_in]).to eql([:text, :pretext])
   end
@@ -87,7 +87,7 @@ RSpec.describe GitHub::EventMessages::Status, type: :model do
     fields = attachments.first[:fields]
     expect(fields).to be_nil
 
-    expect(attachments.first[:footer]).to eql("circle-ci built a2df354c")
+    expect(attachments.first[:footer]).to eql("circle-ci built a2df354c") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:footer_icon]).to eql("https://cloud.githubusercontent.com/assets/38/16295346/2b121e26-38db-11e6-9c4f-ee905519fdf3.png") # rubocop:disable Metrics/LineLength
     expect(attachments.first[:mrkdwn_in]).to eql([:text, :pretext])
   end


### PR DESCRIPTION
This should prevent the Details links from line wrapping on longer branch names. The sha is important but I'm gonna try it out in the footer for a bit.