### PR TITLE
Handle cases where chat initiated from a private room

### DIFF
--- a/app/jobs/webhook_job.rb
+++ b/app/jobs/webhook_job.rb
@@ -35,7 +35,7 @@ class WebhookJob < ApplicationJob
 
       if event_type == "deployment_status" && handler.chat_deployment?
         chat_channel = "##{handler.chat_deployment_room}"
-        if chat_channel != channel
+        if chat_channel != channel && chat_channel != "#privategroup"
           response[:channel] = chat_channel
           team.bot.chat_postMessage(response)
         end


### PR DESCRIPTION
Private rooms can't be posted back to so chat initiated deployments blow up and loop indefinitely when trying to post to private groups. This prevents the exception by blocking postbacks to private rooms.